### PR TITLE
Fix content size height bug on scroll view

### DIFF
--- a/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.m
+++ b/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.m
@@ -162,7 +162,7 @@
 
 - (void) reloadData {
     NSUInteger visiblePages = ceilf(self.frame.size.width/self.pageSize.width);
-    [scrollView setContentSize:CGSizeMake(self.pageSize.width*visiblePages, scrollView.frame.size.width)];
+    [scrollView setContentSize:CGSizeMake(self.pageSize.width*visiblePages, scrollView.frame.size.height)];
     
     if (dataSource != nil) {
         [scrollView setContentOffset:CGPointMake(self.pageSize.width, 0.0f)];


### PR DESCRIPTION
I think you're setting the frame width to the scroll view's content height. Fixing it here.
