### PR TITLE
Expose the UIScrollViewDelegate events so they can be subscribed to by a...

### DIFF
--- a/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.h
+++ b/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.h
@@ -26,6 +26,8 @@ typedef void(^DMCircularScrollViewPageChanged)(NSUInteger currentPageIndex,NSUIn
 @property (nonatomic,assign)    BOOL                                displayBorder;          // Display a green border around the scrollView
 @property (copy)                DMCircularScrollViewPageChanged     handlePageChange;       // Block to catch page change event
 
+@property (nonatomic, assign)   id                                  scrollViewDelegate;     // Delegate for passing through UIScrollView delegate calls
+
 // Use this to setup DMCircularScrollView
 - (void) setPageCount:(NSUInteger) pageCount withDataSource:(DMCircularScrollViewDataSource) dataSource;
 


### PR DESCRIPTION
...nother view controller.

This is helpful for providing users a bit more control during scrollview dragging. We used this internally to have a second view control crossfade as the scrollview was being dragged.
