### PR TITLE
fixed param type

### DIFF
--- a/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.m
+++ b/DMCircularScrollView/DMCircularScrollView/DMCircularScrollView.m
@@ -196,7 +196,7 @@
     }
 }
 
-- (void)scrollViewDidEndZooming:(UIScrollView *)sv withView:(UIView *)view atScale:(double)scale
+- (void)scrollViewDidEndZooming:(UIScrollView *)sv withView:(UIView *)view atScale:(CGFloat)scale
 {
     if (self.scrollViewDelegate && [self.scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndZooming:withView:atScale:)])
     {


### PR DESCRIPTION
I could not compile examples because of this:
![screen shot 2016-01-23 at 6 04 58 pm](https://cloud.githubusercontent.com/assets/1014802/12531488/5d7d0d9a-c1fc-11e5-884b-a79e53aa859a.png)
So this should fix that, but I am not sure why it needed fixing as there is this PR #10 which either broke that or there is some problem with XCode versions (I have 7.2)
